### PR TITLE
Migrate URL shortener to a React island

### DIFF
--- a/frontend/src/components/UrlShortener.jsx
+++ b/frontend/src/components/UrlShortener.jsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+
+// Reads the CSRF token from the hidden input {% csrf_token %} renders in new_base.html
+// (the cookie is HttpOnly, so it isn't JS-readable).
+function csrfToken() {
+  const el = document.querySelector("[name=csrfmiddlewaretoken]");
+  return el ? el.value : "";
+}
+
+// React version of the URL shortener tool. Improves on the old jQuery form with a
+// loading state, inline error handling, and copy feedback (instead of a blocking
+// alert). `submitUrl` comes from the mount point's data-submit-url attribute.
+export default function UrlShortener({ submitUrl }) {
+  const [url, setUrl] = useState("");
+  const [shortened, setShortened] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function submit(e) {
+    e.preventDefault();
+    if (!url.trim()) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(submitUrl, {
+        method: "POST",
+        headers: { "X-CSRFToken": csrfToken() },
+        body: new URLSearchParams({ url: url.trim() }),
+      });
+      const data = await res.json();
+      if (res.ok && data.shortened_url) {
+        setShortened(data.shortened_url);
+        window.trackToolUsage?.("URL Shortener");
+      } else {
+        setShortened("");
+        setError(data.error || "Something went wrong. Please try again.");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(shortened);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable; ignore */
+    }
+  }
+
+  return (
+    <div
+      className="glass-card"
+      style={{
+        minHeight: "45vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <div className="column w-100">
+        <form className="row" onSubmit={submit}>
+          <div className="input-group center-elements p-5">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="URL To Shorten"
+              aria-label="URL To Shorten"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+            <button type="submit" className="btn light-fill" disabled={loading}>
+              <span className="dark-color">
+                {loading ? "Shortening…" : "Shorten URL"}
+              </span>
+            </button>
+          </div>
+        </form>
+
+        {error && (
+          <div className="row">
+            <div className="col text-center">
+              <span className="dark-color">{error}</span>
+            </div>
+          </div>
+        )}
+
+        {shortened && (
+          <div
+            className="row"
+            style={{ justifyContent: "center", alignItems: "center" }}
+          >
+            <div className="input-group center-elements w-50 px-5">
+              <input
+                type="text"
+                className="form-control"
+                aria-label="Shortened URL"
+                value={shortened}
+                readOnly
+              />
+              <button
+                type="button"
+                className="btn light-fill"
+                onClick={copy}
+                aria-label="Copy shortened URL"
+              >
+                <i
+                  className={`${copied ? "fas fa-check" : "far fa-clipboard"} dark-color`}
+                ></i>
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,26 +2,40 @@ import { createRoot } from "react-dom/client";
 import ProjectList from "./components/ProjectList.jsx";
 import SocialLinks from "./components/SocialLinks.jsx";
 import ThemeToggle from "./components/ThemeToggle.jsx";
+import UrlShortener from "./components/UrlShortener.jsx";
 
-// Island registry. A DOM node opts in with data-react-component="<name>" and gets its
-// props from a {% ... |json_script:"id" %} element referenced via data-props-id.
+// Island registry. A DOM node opts in with data-react-component="<name>". Props come
+// from a {% ... |json_script:"id" %} element referenced via data-props-id (for
+// structured data) and/or plain data-* attributes (for simple scalar values).
 const COMPONENTS = {
   ProjectList,
   SocialLinks,
   ThemeToggle,
+  UrlShortener,
 };
 
 function readProps(el) {
+  const props = {};
+
+  // Structured props from a json_script element.
   const id = el.dataset.propsId;
-  if (!id) return {};
-  const node = document.getElementById(id);
-  if (!node) return {};
-  try {
-    return JSON.parse(node.textContent);
-  } catch (e) {
-    console.error(`[islands] bad props JSON in #${id}:`, e);
-    return {};
+  if (id) {
+    const node = document.getElementById(id);
+    if (node) {
+      try {
+        Object.assign(props, JSON.parse(node.textContent));
+      } catch (e) {
+        console.error(`[islands] bad props JSON in #${id}:`, e);
+      }
+    }
   }
+
+  // Scalar props from data-* attributes (camelCased), excluding the control ones.
+  for (const [key, value] of Object.entries(el.dataset)) {
+    if (key !== "reactComponent" && key !== "propsId") props[key] = value;
+  }
+
+  return props;
 }
 
 function mountIslands() {

--- a/mainwebsite/templates/url_shortener.html
+++ b/mainwebsite/templates/url_shortener.html
@@ -1,61 +1,20 @@
 {% extends 'new_base.html' %}
 
-{% block js %}
-    <script>
-        function copyUrl() {
-            /* Get the text field */
-            let copyText = document.getElementById("shortenedUrlField");
-
-            /* Select the text field */
-            copyText.select();
-            copyText.setSelectionRange(0, 99999); /* For mobile devices */
-
-            /* Copy the text inside the text field */
-            navigator.clipboard.writeText(copyText.value);
-
-            /* Alert the copied text */
-            alert("Copied the text: " + copyText.value);
-        }
-
-        function submitForm() {
-            $.ajax({
-                url: "{% url 'mainwebsite:urlShortenerSubmit' %}",
-                dataType: "json",
-                type: "POST",
-                async: true,
-                data: {
-                    "url": $("#urlInput").val(),
-                    'csrfmiddlewaretoken': $("[name=csrfmiddlewaretoken]").val()
-                },
-                success: function (data) {
-                    $("#shortenedUrlArea").show()
-                    $("#shortenedUrlField").val(data['shortened_url'])
-                }
-            });
-        }
-    </script>
-{% endblock %}
-
 {% block content %}
+<div data-react-component="UrlShortener"
+     data-submit-url="{% url 'mainwebsite:urlShortenerSubmit' %}">
+    {# Server-rendered fallback (non-interactive without JS); React replaces it on mount. #}
     <div class="glass-card"
-         style="height: 45vh; opacity: 0; display: flex; justify-content: center; align-items: center;">
+         style="min-height: 45vh; display: flex; justify-content: center; align-items: center;">
         <div class="column w-100">
             <div class="row">
                 <div class="input-group center-elements p-5">
                     <input type="text" class="form-control" aria-label="URL To Shorten"
-                           aria-describedby="inputGroup-sizing-default" placeholder="URL To Shorten" id="urlInput">
-                    <button type="button" class="btn light-fill" onclick="submitForm()"><span
-                            class="dark-color">Shorten URL</span></button>
-                </div>
-            </div>
-
-            <div id="shortenedUrlArea" class="row" style="display: none; justify-content: center; align-items: center;">
-                <div class="input-group center-elements w-50 px-5">
-                    <input type="text" class="form-control" aria-label="Shortened URL"
-                            aria-describedby="inputGroup-sizing-default" placeholder="Shortened URL" id="shortenedUrlField">
-                    <button type="button" class="btn light-fill" onclick="copyUrl()"><i class="far fa-clipboard"></i></button>
+                           placeholder="URL To Shorten">
+                    <button type="button" class="btn light-fill"><span class="dark-color">Shorten URL</span></button>
                 </div>
             </div>
         </div>
     </div>
+</div>
 {% endblock %}

--- a/mainwebsite/test_islands.py
+++ b/mainwebsite/test_islands.py
@@ -107,3 +107,26 @@ class ThemeSystemTests(TestCase):
         self.assertNotIn("switchMode", self.html)
         self.assertNotIn("temp-fill", self.html)
         self.assertNotIn('id="switchButton"', self.html)
+
+
+class UrlShortenerPageTests(TestCase):
+    def setUp(self):
+        self.html = self.client.get(
+            reverse("mainwebsite:urlShortener")
+        ).content.decode()
+
+    def test_mounts_react_island_with_submit_url(self):
+        self.assertIn('data-react-component="UrlShortener"', self.html)
+        self.assertIn(
+            'data-submit-url="%s"' % reverse("mainwebsite:urlShortenerSubmit"),
+            self.html,
+        )
+
+    def test_server_rendered_fallback_present(self):
+        # The form is in the server HTML so the page isn't blank before React mounts.
+        self.assertIn("URL To Shorten", self.html)
+        self.assertIn("Shorten URL", self.html)
+
+    def test_old_jquery_handlers_removed(self):
+        self.assertNotIn("submitForm()", self.html)
+        self.assertNotIn("$.ajax", self.html)


### PR DESCRIPTION
Converts the URL shortener tool from a jQuery `$.ajax` form to a `UrlShortener` React island.

> **Stacks on #19** (the CSS-variable theme). Review/merge #19 first; once it's in `primary`, this PR's diff collapses to just the URL-shortener changes.

## Improvements over the old jQuery version
- Loading state on submit
- **Inline error handling** — the backend returns `{error}` on invalid input, which the old code silently ignored
- Copy-confirmation feedback (checkmark) instead of a blocking `alert()`

## Notes
- `main.jsx`: islands now also accept scalar props from `data-*` attributes (so the submit URL needs no extra `json_script`).
- Server-rendered fallback form remains for no-JS/visual presence; React replaces it on mount.

## Verification
- 155 tests pass (3 new).
- Headless Playwright: renders correctly in light **and** dark, and a real submit against the backend returns a working shortened URL (`/r/LCFUPw`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)