### PR TITLE
Migrate translator to a React island (fixes pre-existing 500)

### DIFF
--- a/frontend/src/components/Translator.jsx
+++ b/frontend/src/components/Translator.jsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+
+function csrfToken() {
+  const el = document.querySelector("[name=csrfmiddlewaretoken]");
+  return el ? el.value : "";
+}
+
+// React version of the two-way translator-call form. The original jQuery fired the POST
+// and showed no feedback at all; this adds a loading state and a success/error message.
+// `submitUrl` comes from the mount point's data-submit-url attribute.
+export default function Translator({ submitUrl }) {
+  const [caller, setCaller] = useState("");
+  const [callee, setCallee] = useState("");
+  const [accessCode, setAccessCode] = useState("");
+  const [status, setStatus] = useState(null); // null | "loading" | "ok" | "error"
+
+  async function submit(e) {
+    e.preventDefault();
+    setStatus("loading");
+    try {
+      const res = await fetch(submitUrl, {
+        method: "POST",
+        headers: { "X-CSRFToken": csrfToken() },
+        body: new URLSearchParams({
+          caller_phone_number: caller,
+          callee_phone_number: callee,
+          access_code: accessCode,
+        }),
+      });
+      setStatus(res.ok ? "ok" : "error");
+      if (res.ok) window.trackToolUsage?.("Language Translator");
+    } catch {
+      setStatus("error");
+    }
+  }
+
+  return (
+    <div
+      className="glass-card"
+      style={{
+        minHeight: "45vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <div className="column w-100">
+        <form className="row" onSubmit={submit}>
+          <div className="input-group center-elements p-5">
+            <input
+              type="text"
+              className="form-control"
+              aria-label="Caller Phone Number"
+              placeholder="Caller Phone Number"
+              value={caller}
+              onChange={(e) => setCaller(e.target.value)}
+            />
+            <input
+              type="text"
+              className="form-control"
+              aria-label="Callee Phone Number"
+              placeholder="Callee Phone Number"
+              value={callee}
+              onChange={(e) => setCallee(e.target.value)}
+            />
+            <input
+              type="text"
+              className="form-control"
+              aria-label="Access Code"
+              placeholder="Access Code"
+              value={accessCode}
+              onChange={(e) => setAccessCode(e.target.value)}
+            />
+            <button
+              type="submit"
+              className="btn light-fill"
+              disabled={status === "loading"}
+            >
+              <span className="dark-color">
+                {status === "loading" ? "Calling…" : "Initiate Call"}
+              </span>
+            </button>
+          </div>
+        </form>
+
+        {status === "ok" && (
+          <div className="row">
+            <div className="col text-center">
+              <span className="dark-color">Call initiated.</span>
+            </div>
+          </div>
+        )}
+        {status === "error" && (
+          <div className="row">
+            <div className="col text-center">
+              <span className="dark-color">
+                Could not initiate the call. Check the numbers and try again.
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/UrlShortener.jsx
+++ b/frontend/src/components/UrlShortener.jsx
@@ -1,0 +1,122 @@
+import { useState } from "react";
+
+// Reads the CSRF token from the hidden input {% csrf_token %} renders in new_base.html
+// (the cookie is HttpOnly, so it isn't JS-readable).
+function csrfToken() {
+  const el = document.querySelector("[name=csrfmiddlewaretoken]");
+  return el ? el.value : "";
+}
+
+// React version of the URL shortener tool. Improves on the old jQuery form with a
+// loading state, inline error handling, and copy feedback (instead of a blocking
+// alert). `submitUrl` comes from the mount point's data-submit-url attribute.
+export default function UrlShortener({ submitUrl }) {
+  const [url, setUrl] = useState("");
+  const [shortened, setShortened] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  async function submit(e) {
+    e.preventDefault();
+    if (!url.trim()) return;
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(submitUrl, {
+        method: "POST",
+        headers: { "X-CSRFToken": csrfToken() },
+        body: new URLSearchParams({ url: url.trim() }),
+      });
+      const data = await res.json();
+      if (res.ok && data.shortened_url) {
+        setShortened(data.shortened_url);
+        window.trackToolUsage?.("URL Shortener");
+      } else {
+        setShortened("");
+        setError(data.error || "Something went wrong. Please try again.");
+      }
+    } catch {
+      setError("Network error. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(shortened);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* clipboard unavailable; ignore */
+    }
+  }
+
+  return (
+    <div
+      className="glass-card"
+      style={{
+        minHeight: "45vh",
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+    >
+      <div className="column w-100">
+        <form className="row" onSubmit={submit}>
+          <div className="input-group center-elements p-5">
+            <input
+              type="text"
+              className="form-control"
+              placeholder="URL To Shorten"
+              aria-label="URL To Shorten"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+            />
+            <button type="submit" className="btn light-fill" disabled={loading}>
+              <span className="dark-color">
+                {loading ? "Shortening…" : "Shorten URL"}
+              </span>
+            </button>
+          </div>
+        </form>
+
+        {error && (
+          <div className="row">
+            <div className="col text-center">
+              <span className="dark-color">{error}</span>
+            </div>
+          </div>
+        )}
+
+        {shortened && (
+          <div
+            className="row"
+            style={{ justifyContent: "center", alignItems: "center" }}
+          >
+            <div className="input-group center-elements w-50 px-5">
+              <input
+                type="text"
+                className="form-control"
+                aria-label="Shortened URL"
+                value={shortened}
+                readOnly
+              />
+              <button
+                type="button"
+                className="btn light-fill"
+                onClick={copy}
+                aria-label="Copy shortened URL"
+              >
+                <i
+                  className={`${copied ? "fas fa-check" : "far fa-clipboard"} dark-color`}
+                ></i>
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,26 +2,40 @@ import { createRoot } from "react-dom/client";
 import ProjectList from "./components/ProjectList.jsx";
 import SocialLinks from "./components/SocialLinks.jsx";
 import ThemeToggle from "./components/ThemeToggle.jsx";
+import UrlShortener from "./components/UrlShortener.jsx";
 
-// Island registry. A DOM node opts in with data-react-component="<name>" and gets its
-// props from a {% ... |json_script:"id" %} element referenced via data-props-id.
+// Island registry. A DOM node opts in with data-react-component="<name>". Props come
+// from a {% ... |json_script:"id" %} element referenced via data-props-id (for
+// structured data) and/or plain data-* attributes (for simple scalar values).
 const COMPONENTS = {
   ProjectList,
   SocialLinks,
   ThemeToggle,
+  UrlShortener,
 };
 
 function readProps(el) {
+  const props = {};
+
+  // Structured props from a json_script element.
   const id = el.dataset.propsId;
-  if (!id) return {};
-  const node = document.getElementById(id);
-  if (!node) return {};
-  try {
-    return JSON.parse(node.textContent);
-  } catch (e) {
-    console.error(`[islands] bad props JSON in #${id}:`, e);
-    return {};
+  if (id) {
+    const node = document.getElementById(id);
+    if (node) {
+      try {
+        Object.assign(props, JSON.parse(node.textContent));
+      } catch (e) {
+        console.error(`[islands] bad props JSON in #${id}:`, e);
+      }
+    }
   }
+
+  // Scalar props from data-* attributes (camelCased), excluding the control ones.
+  for (const [key, value] of Object.entries(el.dataset)) {
+    if (key !== "reactComponent" && key !== "propsId") props[key] = value;
+  }
+
+  return props;
 }
 
 function mountIslands() {

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import ProjectList from "./components/ProjectList.jsx";
 import SocialLinks from "./components/SocialLinks.jsx";
 import ThemeToggle from "./components/ThemeToggle.jsx";
+import Translator from "./components/Translator.jsx";
 import UrlShortener from "./components/UrlShortener.jsx";
 
 // Island registry. A DOM node opts in with data-react-component="<name>". Props come
@@ -11,6 +12,7 @@ const COMPONENTS = {
   ProjectList,
   SocialLinks,
   ThemeToggle,
+  Translator,
   UrlShortener,
 };
 

--- a/mainwebsite/templates/translator.html
+++ b/mainwebsite/templates/translator.html
@@ -1,40 +1,24 @@
 {% extends 'new_base.html' %}
 
-{% block js %}
-    <script>
-        function submitForm() {
-            $.ajax({
-                url: "{% url 'start_two_way' %}",
-                dataType: "json",
-                type: "POST",
-                async: true,
-                data: {
-                    "caller_phone_number": $("#callerNumber").val(),
-                    "callee_phone_number": $("#calleeNumber").val(),
-                    "access_code": $("#accessCode").val(),
-                    'csrfmiddlewaretoken': $("[name=csrfmiddlewaretoken]").val()
-                }
-            });
-        }
-    </script>
-{% endblock %}
-
 {% block content %}
+<div data-react-component="Translator"
+     data-submit-url="{% url 'mainwebsite:start_two_way' %}">
+    {# Server-rendered fallback (non-interactive without JS); React replaces it on mount. #}
     <div class="glass-card"
-    style="height: 45vh; opacity: 0; display: flex; justify-content: center; align-items: center;">
+         style="min-height: 45vh; display: flex; justify-content: center; align-items: center;">
         <div class="column w-100">
             <div class="row">
                 <div class="input-group center-elements p-5">
                     <input type="text" class="form-control" aria-label="Caller Phone Number"
-                            aria-describedby="inputGroup-sizing-default" placeholder="Caller Phone Number" id="callerNumber">
+                           placeholder="Caller Phone Number">
                     <input type="text" class="form-control" aria-label="Callee Phone Number"
-                            aria-describedby="inputGroup-sizing-default" placeholder="Callee Phone Number" id="calleeNumber">
+                           placeholder="Callee Phone Number">
                     <input type="text" class="form-control" aria-label="Access Code"
-                            aria-describedby="inputGroup-sizing-default" placeholder="Access Code" id="accessCode">
-                    <button type="button" class="btn light-fill" onclick="submitForm()"><span
-                            class="dark-color">Initiate Call</span></button>
+                           placeholder="Access Code">
+                    <button type="button" class="btn light-fill"><span class="dark-color">Initiate Call</span></button>
                 </div>
             </div>
         </div>
     </div>
+</div>
 {% endblock %}

--- a/mainwebsite/templates/url_shortener.html
+++ b/mainwebsite/templates/url_shortener.html
@@ -1,61 +1,20 @@
 {% extends 'new_base.html' %}
 
-{% block js %}
-    <script>
-        function copyUrl() {
-            /* Get the text field */
-            let copyText = document.getElementById("shortenedUrlField");
-
-            /* Select the text field */
-            copyText.select();
-            copyText.setSelectionRange(0, 99999); /* For mobile devices */
-
-            /* Copy the text inside the text field */
-            navigator.clipboard.writeText(copyText.value);
-
-            /* Alert the copied text */
-            alert("Copied the text: " + copyText.value);
-        }
-
-        function submitForm() {
-            $.ajax({
-                url: "{% url 'mainwebsite:urlShortenerSubmit' %}",
-                dataType: "json",
-                type: "POST",
-                async: true,
-                data: {
-                    "url": $("#urlInput").val(),
-                    'csrfmiddlewaretoken': $("[name=csrfmiddlewaretoken]").val()
-                },
-                success: function (data) {
-                    $("#shortenedUrlArea").show()
-                    $("#shortenedUrlField").val(data['shortened_url'])
-                }
-            });
-        }
-    </script>
-{% endblock %}
-
 {% block content %}
+<div data-react-component="UrlShortener"
+     data-submit-url="{% url 'mainwebsite:urlShortenerSubmit' %}">
+    {# Server-rendered fallback (non-interactive without JS); React replaces it on mount. #}
     <div class="glass-card"
-         style="height: 45vh; opacity: 0; display: flex; justify-content: center; align-items: center;">
+         style="min-height: 45vh; display: flex; justify-content: center; align-items: center;">
         <div class="column w-100">
             <div class="row">
                 <div class="input-group center-elements p-5">
                     <input type="text" class="form-control" aria-label="URL To Shorten"
-                           aria-describedby="inputGroup-sizing-default" placeholder="URL To Shorten" id="urlInput">
-                    <button type="button" class="btn light-fill" onclick="submitForm()"><span
-                            class="dark-color">Shorten URL</span></button>
-                </div>
-            </div>
-
-            <div id="shortenedUrlArea" class="row" style="display: none; justify-content: center; align-items: center;">
-                <div class="input-group center-elements w-50 px-5">
-                    <input type="text" class="form-control" aria-label="Shortened URL"
-                            aria-describedby="inputGroup-sizing-default" placeholder="Shortened URL" id="shortenedUrlField">
-                    <button type="button" class="btn light-fill" onclick="copyUrl()"><i class="far fa-clipboard"></i></button>
+                           placeholder="URL To Shorten">
+                    <button type="button" class="btn light-fill"><span class="dark-color">Shorten URL</span></button>
                 </div>
             </div>
         </div>
     </div>
+</div>
 {% endblock %}

--- a/mainwebsite/test_islands.py
+++ b/mainwebsite/test_islands.py
@@ -130,3 +130,25 @@ class UrlShortenerPageTests(TestCase):
     def test_old_jquery_handlers_removed(self):
         self.assertNotIn("submitForm()", self.html)
         self.assertNotIn("$.ajax", self.html)
+
+
+class TranslatorPageTests(TestCase):
+    def setUp(self):
+        self.response = self.client.get(reverse("mainwebsite:translator"))
+        self.html = self.response.content.decode()
+
+    def test_page_renders(self):
+        # Regression: the old template used a non-namespaced {% url 'start_two_way' %}
+        # which raised NoReverseMatch (500). It must reverse and render now.
+        self.assertEqual(self.response.status_code, 200)
+
+    def test_mounts_react_island_with_namespaced_submit_url(self):
+        self.assertIn('data-react-component="Translator"', self.html)
+        self.assertIn(
+            'data-submit-url="%s"' % reverse("mainwebsite:start_two_way"),
+            self.html,
+        )
+
+    def test_old_jquery_handler_removed(self):
+        self.assertNotIn("submitForm()", self.html)
+        self.assertNotIn("$.ajax", self.html)

--- a/mainwebsite/test_islands.py
+++ b/mainwebsite/test_islands.py
@@ -107,3 +107,26 @@ class ThemeSystemTests(TestCase):
         self.assertNotIn("switchMode", self.html)
         self.assertNotIn("temp-fill", self.html)
         self.assertNotIn('id="switchButton"', self.html)
+
+
+class UrlShortenerPageTests(TestCase):
+    def setUp(self):
+        self.html = self.client.get(
+            reverse("mainwebsite:urlShortener")
+        ).content.decode()
+
+    def test_mounts_react_island_with_submit_url(self):
+        self.assertIn('data-react-component="UrlShortener"', self.html)
+        self.assertIn(
+            'data-submit-url="%s"' % reverse("mainwebsite:urlShortenerSubmit"),
+            self.html,
+        )
+
+    def test_server_rendered_fallback_present(self):
+        # The form is in the server HTML so the page isn't blank before React mounts.
+        self.assertIn("URL To Shorten", self.html)
+        self.assertIn("Shorten URL", self.html)
+
+    def test_old_jquery_handlers_removed(self):
+        self.assertNotIn("submitForm()", self.html)
+        self.assertNotIn("$.ajax", self.html)


### PR DESCRIPTION
Converts the translator-call form to a `Translator` React island — **and fixes a bug found during verification**.

> **Stacks on #19 → #20.** Review/merge those first; this PR's diff collapses to just the translator changes once they're in `primary`.

## Bug fixed
The old template used `{% url 'start_two_way' %}` without the `mainwebsite:` namespace, so it raised `NoReverseMatch` — **the translator page was returning a 500 in production**. Now uses `{% url 'mainwebsite:start_two_way' %}`. Caught by the Playwright screenshot pass (the page rendered Django's error page instead of the form).

## Migration
- `Translator.jsx`: `fetch` POST with the CSRF token from the hidden input; adds a loading state and success/error feedback the original had none of.
- Server-rendered fallback form remains; jQuery removed.

## Verification
- 158 tests pass, including a regression test asserting the page now returns 200.
- Headless Playwright confirms light/dark render. (The actual Twilio call isn't exercised — it needs live credentials.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)