### PR TITLE
Migrate resume page to React + GlassCard primitive

### DIFF
--- a/frontend/src/components/GlassCard.jsx
+++ b/frontend/src/components/GlassCard.jsx
@@ -1,0 +1,9 @@
+// Design-system primitive: the frosted "glass" card used across the site. Wraps the
+// existing .glass-card CSS so pages compose a component instead of repeating markup.
+export default function GlassCard({ className = "", children, ...rest }) {
+  return (
+    <div className={`glass-card ${className}`.trim()} {...rest}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/Resume.jsx
+++ b/frontend/src/components/Resume.jsx
@@ -1,0 +1,44 @@
+import GlassCard from "./GlassCard.jsx";
+
+// Resume page: embeds the PDF with a download link. `pdfUrl` comes from the mount
+// point's data-pdf-url attribute (resolved by Django's {% static %}).
+export default function Resume({ pdfUrl }) {
+  return (
+    <GlassCard>
+      <div className="card-body p-4">
+        <div className="row mb-3">
+          <div className="col text-center">
+            <h1 className="dark-color">Resume</h1>
+          </div>
+        </div>
+        <div className="row mb-3">
+          <div className="col text-center">
+            <a
+              href={pdfUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="btn btn-primary me-2"
+              onClick={() => window.trackResumeDownload?.()}
+            >
+              Download PDF
+            </a>
+          </div>
+        </div>
+        <div className="row">
+          <div className="col">
+            <iframe
+              src={pdfUrl}
+              style={{
+                width: "100%",
+                height: "80vh",
+                border: "none",
+                borderRadius: "10px",
+              }}
+              title="Atilano Garcia Resume"
+            />
+          </div>
+        </div>
+      </div>
+    </GlassCard>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import ProjectList from "./components/ProjectList.jsx";
+import Resume from "./components/Resume.jsx";
 import SocialLinks from "./components/SocialLinks.jsx";
 import ThemeToggle from "./components/ThemeToggle.jsx";
 import Translator from "./components/Translator.jsx";
@@ -10,6 +11,7 @@ import UrlShortener from "./components/UrlShortener.jsx";
 // structured data) and/or plain data-* attributes (for simple scalar values).
 const COMPONENTS = {
   ProjectList,
+  Resume,
   SocialLinks,
   ThemeToggle,
   Translator,

--- a/mainwebsite/templates/resume.html
+++ b/mainwebsite/templates/resume.html
@@ -2,34 +2,31 @@
 {% load static %}
 
 {% block content %}
-<div class="glass-card" style="opacity: 0;">
-    <div class="card-body p-4">
-        <div class="row mb-3">
-            <div class="col text-center">
-                <h1 class="dark-color">Resume</h1>
+<div data-react-component="Resume"
+     data-pdf-url="{% static 'mainwebsite/files/Atilano (Tilo) Garcia Resume.pdf' %}">
+    {# Server-rendered fallback; React replaces it on mount. #}
+    <div class="glass-card">
+        <div class="card-body p-4">
+            <div class="row mb-3">
+                <div class="col text-center">
+                    <h1 class="dark-color">Resume</h1>
+                </div>
             </div>
-        </div>
-        <div class="row mb-3">
-            <div class="col text-center">
-                <a href="{% static 'mainwebsite/files/Atilano (Tilo) Garcia Resume.pdf' %}"
-                   target="_blank"
-                   class="btn btn-primary me-2"
-                   onclick="trackResumeDownload()">
-                    Download PDF
-                </a>
+            <div class="row mb-3">
+                <div class="col text-center">
+                    <a href="{% static 'mainwebsite/files/Atilano (Tilo) Garcia Resume.pdf' %}"
+                       target="_blank" class="btn btn-primary me-2" onclick="trackResumeDownload()">
+                        Download PDF
+                    </a>
+                </div>
             </div>
-        </div>
-        <div class="row">
-            <div class="col">
-                <iframe
-                    src="{% static 'mainwebsite/files/Atilano (Tilo) Garcia Resume.pdf' %}"
-                    style="width: 100%; height: 80vh; border: none; border-radius: 10px;"
-                    title="Atilano Garcia Resume">
-                    <p class="dark-color text-center">
-                        Your browser doesn't support embedded PDFs.
-                        <a href="{% static 'mainwebsite/files/Atilano (Tilo) Garcia Resume.pdf' %}" target="_blank">Download the resume here.</a>
-                    </p>
-                </iframe>
+            <div class="row">
+                <div class="col">
+                    <iframe src="{% static 'mainwebsite/files/Atilano (Tilo) Garcia Resume.pdf' %}"
+                            style="width: 100%; height: 80vh; border: none; border-radius: 10px;"
+                            title="Atilano Garcia Resume">
+                    </iframe>
+                </div>
             </div>
         </div>
     </div>

--- a/mainwebsite/test_islands.py
+++ b/mainwebsite/test_islands.py
@@ -152,3 +152,19 @@ class TranslatorPageTests(TestCase):
     def test_old_jquery_handler_removed(self):
         self.assertNotIn("submitForm()", self.html)
         self.assertNotIn("$.ajax", self.html)
+
+
+class ResumeIslandTests(TestCase):
+    def setUp(self):
+        self.response = self.client.get(reverse("mainwebsite:resume"))
+        self.html = self.response.content.decode()
+
+    def test_mounts_resume_island_with_pdf_url(self):
+        self.assertEqual(self.response.status_code, 200)
+        self.assertIn('data-react-component="Resume"', self.html)
+        self.assertIn("data-pdf-url=", self.html)
+
+    def test_server_rendered_fallback_present(self):
+        # Heading + embedded PDF remain in the server HTML for SEO / no-JS.
+        self.assertIn("<iframe", self.html)
+        self.assertIn(".pdf", self.html)


### PR DESCRIPTION
First static page migrated, and the first reusable design-system primitive.

> **Stacks on #19 → #20 → #21.** Diffs clean up as those merge into `primary`.

- **`GlassCard.jsx`** — design-system primitive wrapping the `.glass-card` CSS, so pages compose a component instead of repeating markup. This is the seed of the component library.
- **`Resume.jsx`** — composes `GlassCard`; heading + Download PDF + embedded iframe. PDF URL via `data-pdf-url`.
- Server-rendered fallback kept for SEO / no-JS.

## Verification
- 160 tests pass.
- Headless Playwright confirms light/dark render (the embedded PDF is blank only because headless Chromium doesn't render it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)