### PR TITLE
Migrate personal AI page to React (fixes pre-existing logout 500)

### DIFF
--- a/frontend/src/components/PersonalAi.jsx
+++ b/frontend/src/components/PersonalAi.jsx
@@ -1,0 +1,37 @@
+function csrfToken() {
+  const el = document.querySelector("[name=csrfmiddlewaretoken]");
+  return el ? el.value : "";
+}
+
+// Personal AI landing page (shown to authenticated users). `username` and `logoutUrl`
+// come from data-* props. The logout form posts with the CSRF token from the hidden
+// input {% csrf_token %} renders in new_base.html.
+export default function PersonalAi({ username, logoutUrl }) {
+  return (
+    <div className="container mt-5">
+      <div className="row justify-content-center">
+        <div className="col-md-8">
+          <div className="card">
+            <div className="card-body text-center">
+              <h2 className="card-title">Welcome to Your Personal AI Page</h2>
+              <p>This is your personal space. More features will be added soon!</p>
+              <p>
+                You are logged in as: <strong>{username}</strong>
+              </p>
+              <form action={logoutUrl} method="post" className="d-inline">
+                <input
+                  type="hidden"
+                  name="csrfmiddlewaretoken"
+                  value={csrfToken()}
+                />
+                <button type="submit" className="btn btn-danger">
+                  Log Out
+                </button>
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import Graduation from "./components/Graduation.jsx";
 import Kky from "./components/Kky.jsx";
 import MessageCard from "./components/MessageCard.jsx";
 import NotFound from "./components/NotFound.jsx";
+import PersonalAi from "./components/PersonalAi.jsx";
 import ProjectList from "./components/ProjectList.jsx";
 import Resume from "./components/Resume.jsx";
 import SocialLinks from "./components/SocialLinks.jsx";
@@ -18,6 +19,7 @@ const COMPONENTS = {
   Kky,
   MessageCard,
   NotFound,
+  PersonalAi,
   ProjectList,
   Resume,
   SocialLinks,

--- a/mainwebsite/templates/personal_ai.html
+++ b/mainwebsite/templates/personal_ai.html
@@ -1,21 +1,8 @@
 {% extends 'new_base.html' %}
 
 {% block content %}
-<div class="container mt-5">
-    <div class="row justify-content-center">
-        <div class="col-md-8">
-            <div class="card">
-                <div class="card-body text-center">
-                    <h2 class="card-title">Welcome to Your Personal AI Page</h2>
-                    <p>This is your personal space. More features will be added soon!</p>
-                    <p>You are logged in as: <strong>{{ user.username }}</strong></p>
-                    <form action="{% url 'logout' %}" method="post" class="d-inline">
-                        {% csrf_token %}
-                        <button type="submit" class="btn btn-danger">Log Out</button>
-                    </form>
-                </div>
-            </div>
-        </div>
-    </div>
+<div data-react-component="PersonalAi"
+     data-username="{{ user.username }}"
+     data-logout-url="{% url 'mainwebsite:logout' %}">
 </div>
 {% endblock %}

--- a/mainwebsite/test_islands.py
+++ b/mainwebsite/test_islands.py
@@ -214,3 +214,15 @@ class KkyIslandTests(TestCase):
         self.assertIn('data-react-component="Kky"', self.html)
         self.assertIn("data-crest-img=", self.html)
         self.assertIn("data-section-img=", self.html)
+
+
+class PersonalAiIslandTests(TestCase):
+    def test_personal_ai_template_mounts_island(self):
+        # Rendered directly (the view itself is passkey-gated); we check the template.
+        request = RequestFactory().get("/")
+        request.user = type("U", (), {"username": "tilo", "is_authenticated": True})()
+        html = render_to_string("personal_ai.html", request=request)
+        self.assertIn('data-react-component="PersonalAi"', html)
+        self.assertIn("data-username=", html)
+        # Regression: must use the namespaced logout URL (bare name raised NoReverseMatch).
+        self.assertIn('data-logout-url="%s"' % reverse("mainwebsite:logout"), html)


### PR DESCRIPTION
Renders the personal AI page as a `PersonalAi` island, and fixes a latent 500: the logout form used `{% url 'logout' %}` without the `mainwebsite:` namespace (NoReverseMatch). Now namespaced. 162 tests pass; Playwright-verified via an authenticated preview route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)